### PR TITLE
MIDI relay task (+ static phonemes)

### DIFF
--- a/lib/miku/Flags.hpp
+++ b/lib/miku/Flags.hpp
@@ -1,0 +1,13 @@
+#ifndef MIKU_FLAGS_HPP
+#define MIKU_FLAGS_HPP
+
+/// @brief Flags system so screens can selectively delcare what data they depend on. The App can then apply the correct data to the screen.
+enum DependencyFlags
+{
+    /// @brief The screen needs no special data
+    None = 0,
+    /// @brief The screen needs real-time MIDI events
+    MidiEvents = 1 << 0,
+};
+
+#endif

--- a/lib/miku/tasks/Task.hpp
+++ b/lib/miku/tasks/Task.hpp
@@ -2,6 +2,8 @@
 #ifndef MIKU_TASKS_TASK_HPP
 #define MIKU_TASKS_TASK_HPP
 
+#include "../Flags.hpp"
+
 namespace miku::tasks {
     class Task {
         public:
@@ -37,7 +39,7 @@ namespace miku::tasks {
                 this->enabled = false;
             }
 
-            bool TimerLapsed() {
+            virtual bool TimerLapsed() {
                 if (this->enabled && hardware.system.GetNow() - this->lastExecution >= this->timeout) {
                     return true;
                 }
@@ -47,14 +49,6 @@ namespace miku::tasks {
             std::map<std::string, float> GetDataValues() {
                 return this->dataValues;
             }
-
-            // virtual std::vector<int>* GetAdcPins() {
-            //     return &this->adcPins;
-            // }
-
-            // std::vector<unsigned short>* GetAdcChannelIndices() {
-            //     return &this->adcChannelIndices;
-            // }
 
             short GetAdcPin() {
                 return this->adcPin;
@@ -71,12 +65,20 @@ namespace miku::tasks {
             std::string GetCode() {
                 return this->code;
             }
+
+            /// @brief A mask that represents the dependencies this Task can fulfill/provide to others
+            /// @return The mask
+            DependencyFlags GetDependenciesProvided() {
+                return this->dependenciesProvided;
+            }
         protected:
             std::map<std::string, float> dataValues;
             daisy::DaisySeed hardware;
             short adcPin = -1;
             short adcChannelIndex = -1;
             std::string code;
+            /// @brief A mask of dependencies that this task provides
+            DependencyFlags dependenciesProvided = DependencyFlags::None;
         private:
             unsigned long timeout;
             unsigned long lastExecution = -1;

--- a/lib/miku/tasks/hardware/MidiRelayTask.hpp
+++ b/lib/miku/tasks/hardware/MidiRelayTask.hpp
@@ -1,0 +1,93 @@
+#ifndef MIKU_TASKS_HARDWARE_MIDIRELAYTASK_HPP
+#define MIKU_TASKS_HARDWARE_MIDIRELAYTASK_HPP
+
+#include <vector>
+
+#include "../Task.hpp"
+#include "daisy_seed.h"
+
+namespace miku::tasks::hardware {
+    class MidiRelayTask : public miku::tasks::Task {
+        public:
+            MidiRelayTask(daisy::DaisySeed hardware, unsigned short rxPin, unsigned short txPin) : Task(hardware, "MIDI", 0L) {
+                this->rxPin = rxPin;
+                this->txPin = txPin;
+
+                this->dependenciesProvided = (DependencyFlags)(this->dependenciesProvided | DependencyFlags::MidiEvents);
+
+                this->Init();
+            }
+
+            void Init() {
+                daisy::MidiUartHandler::Config midiConfig;
+                midiConfig.transport_config.periph = daisy::UartHandler::Config::Peripheral::USART_1;
+                midiConfig.transport_config.rx.pin = this->hardware.GetPin(this->rxPin).pin;
+                midiConfig.transport_config.tx.pin = this->hardware.GetPin(this->txPin).pin;
+
+                this->midiHandler.Init(midiConfig);
+                this->midiHandler.StartReceive();
+
+                std::vector<uint8_t> bytes = {
+                    0xF0, 0x43, 0x79, 0x09, 0x00, 0x50, // header
+                    0x10, // mode
+                    0x6B, 0x20, 0x61, 0x2C, 0x34, 0x20, 0x61, 0x2C, 0x61, 0x2C, 0x67, 0x20, 0x65, // ka ra a ge
+                    // 0x61, 0x2C, 0x65, 0x2C, 0x69, 0x2C, 0x6F, 0x2C, 0x4D, // a e i o u, 0x2C = comma/delimiter
+                    // 0x68, 0x20, 0x61, 0x2C, 0x74, 0x73, 0x20, 0x4D, 0x2C, 0x6E, 0x20, 0x65, 0x2C, 0x6D, 0x27, 0x20, 0x69, 0x2C, 0x6B, 0x20, 0x4D, 0x2C, 0x64, 0x20, 0x65, 0x2C, 0x73, 0x20, 0x4D, // hatsune miku desu
+                    0x00, 0xF7  // footer
+                };
+
+                this->midiHandler.SendMessage(bytes.data(), bytes.size());
+            }
+
+            void Execute() {
+                while(this->midiHandler.HasEvents()) {
+                    this->totalEventCount++;
+                    daisy::MidiEvent msg = this->midiHandler.PopEvent();
+
+                    switch(msg.type)
+                    {
+                        // TODO properly calculate channel based on incoming message
+                        case daisy::NoteOn:
+                            {
+                                uint8_t bytes[3] = {0x90, 0x00, 0x00};
+                                bytes[1] = msg.data[0];
+                                bytes[2] = msg.data[1];
+                                this->midiHandler.SendMessage(bytes, 3);
+                            }
+                            break;
+                        case daisy::NoteOff:
+                            {
+                                uint8_t bytes[3] = {0x80, 0x00, 0x00};
+                                bytes[1] = msg.data[0];
+                                bytes[2] = msg.data[1];
+                                this->midiHandler.SendMessage(bytes, 3);
+                            }
+                            break;
+                        default: break;
+                    }
+
+                    /** Regardless of message, let's add the message data to our queue to output */
+                    this->midiEventLog.PushBack(msg);
+                }
+
+                this->dataValues["MIDI_EVENT_COUNT"] = (float)this->totalEventCount;
+            }
+
+            bool TimerLapsed() {
+                // **Always** process MIDI evens on every loop
+                return true;
+            }
+
+            daisy::FIFO<daisy::MidiEvent, 128>* GetMidiEventLog() {
+                return &this->midiEventLog;
+            }
+        private:
+            daisy::MidiUartHandler midiHandler;
+            daisy::FIFO<daisy::MidiEvent, 128> midiEventLog;
+            unsigned short rxPin = 0;
+            unsigned short txPin = 0;
+
+            unsigned long totalEventCount = 0;
+    };
+}
+#endif

--- a/lib/miku/ux/Resources.hpp
+++ b/lib/miku/ux/Resources.hpp
@@ -138,4 +138,25 @@ namespace miku::ux {
 
 }
 
+/// @brief A little glyph of two connected eighth notes, with the left side down (frame 1).
+const bool EIGHTH_NOTE_0[6][5] = {
+    {0,0,0,1,1},
+    {0,1,1,0,1},
+    {0,1,0,0,1},
+    {0,1,0,1,1},
+    {1,1,0,1,1},
+    {1,1,0,0,0}
+};
+
+/// @brief A little glyph of two connected eighth notes, with the left side up (frame 2).
+const bool EIGHTH_NOTE_1[6][5] = {
+    {0,1,1,0,0},
+    {0,1,0,1,1},
+    {0,1,0,0,1},
+    {1,1,0,0,1},
+    {1,1,0,1,1},
+    {0,0,0,1,1}
+};
+
+
 #endif

--- a/lib/miku/ux/Screen.hpp
+++ b/lib/miku/ux/Screen.hpp
@@ -39,10 +39,15 @@ namespace miku::ux {
             std::string GetCode() {
                 return this->code;
             }
+
+            DependencyFlags GetDependencyFlags() {
+                return this->dependencyFlags;
+            }
         protected:
             unsigned short left = 0;
             unsigned short top = 0;
             std::map<std::string, float> dataValues;
+            DependencyFlags dependencyFlags = DependencyFlags::None;
         private:
             std::string code;
             Display* display;

--- a/lib/miku/ux/screens/MidiEventsScreen.hpp
+++ b/lib/miku/ux/screens/MidiEventsScreen.hpp
@@ -1,0 +1,41 @@
+
+#ifndef MIKU_UX_SCREENS_MIDI_EVENTS_SCREEN_HPP
+#define MIKU_UX_SCREENS_MIDI_EVENTS_SCREEN_HPP
+
+#include <vector>
+
+#include "../Screen.hpp"
+#include "../Display.hpp"
+
+#include <stdexcept>
+
+namespace miku::ux::screens {
+    class MidiEventsScreen : public miku::ux::Screen {
+        public:
+            MidiEventsScreen(Display* display) : Screen(display, "ME") {
+                this->dependencyFlags = (DependencyFlags)(this->dependencyFlags | DependencyFlags::MidiEvents);
+            }
+
+            void Render() {
+                this->GetDisplay()->Fill();
+                this->GetDisplay()->DrawStringByRow(1, 0, "MIDI Events");
+
+                char buffer[32];
+                sprintf(buffer, "TSKEvt: %.1f", this->dataValues["MIDI_EVENT_COUNT"]);
+                this->GetDisplay()->DrawStringByRow(2, 0, buffer);
+
+                sprintf(buffer, "DB Evt: %d", this->midiEvents->GetNumElements());
+                this->GetDisplay()->DrawStringByRow(3, 0, buffer);
+
+                this->GetDisplay()->RequestInvalidate();
+            }
+
+            void BindMidiEventLog(daisy::FIFO<daisy::MidiEvent, 128>* midiEvents) {
+                this->midiEvents = midiEvents;
+            }
+        private:
+            daisy::FIFO<daisy::MidiEvent, 128>* midiEvents;
+    };
+}
+
+#endif

--- a/lib/miku/ux/screens/TestScreen.hpp
+++ b/lib/miku/ux/screens/TestScreen.hpp
@@ -41,11 +41,6 @@ namespace miku::ux::screens {
 
                 this->GetDisplay()->RequestInvalidate();
             }
-
-            std::vector<miku::tasks::Task*> GetTasks() {
-                return {};
-            }
-
         private:
             std::string someString;
     };

--- a/miku.cpp
+++ b/miku.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <string>
 #include "daisy_seed.h"
+
 // #include "dev/oled_ssd130x.h"
 
 // #include "lib/miku/ux/Resources.hpp"
@@ -9,8 +10,6 @@
 // #include "lib/miku/midi/midi.hpp"
 
 #include "lib/miku/App.hpp"
-
-// MidiUartHandler midi;
 
 // /** FIFO to hold messages as we're ready to print them */
 // FIFO<MidiEvent, 128> event_log;


### PR DESCRIPTION
Adds the `MidiRelayTask` which listens for incoming MIDI events and relays specific ones to the evy1 chip.

Also added basic (read: static) phonemes. `ka ra a ge` forever!